### PR TITLE
Search declarations and constructors from prefix

### DIFF
--- a/scion-browser.cabal
+++ b/scion-browser.cabal
@@ -1,5 +1,5 @@
 name:           scion-browser
-version:        0.2.7
+version:        0.2.8
 cabal-version:  >= 1.8
 build-type:     Simple
 license:        BSD3

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -6,10 +6,9 @@ import qualified Codec.Compression.Zlib as Zlib
 import Control.Monad.State
 import Data.Aeson
 import qualified Data.Aeson.Types as T
-import qualified Data.Attoparsec.Char8 as Atto
-import qualified Data.Attoparsec.Types as Atto
-import qualified Data.ByteString.Char8 as BS
+import qualified Data.Attoparsec.ByteString as Atto
 import qualified Data.ByteString.Lazy.Char8 as LBS
+import qualified Data.ByteString.UTF8  as BSU(fromString)
 import Server.PersistentCommands
 import System.Console.Haskeline
 import System.IO (hFlush, stdout, stderr)
@@ -28,11 +27,12 @@ main = do args <- getArgs
                                   return ()
 
 loop :: InputT BrowserM ()
-loop = do maybeLine <- getInputLine ""
+loop = do 
+          maybeLine <- getInputLine ""
           case maybeLine of
             Nothing -> return () -- ctrl+D or EOF
             Just line -> do
-              case Atto.parse json (BS.pack line) of
+              case Atto.parse json (BSU.fromString line) of
                 Atto.Fail _ _ e   -> (liftIO $ logToStdout ("error in command: " ++ e)) >> loop
                 Atto.Partial _   -> (liftIO $ logToStdout ("incomplete data error in command: ")) >> loop
                 Atto.Done _ value -> case T.parse parseJSON value of

--- a/src/Scion/PersistentHoogle.hs
+++ b/src/Scion/PersistentHoogle.hs
@@ -26,7 +26,10 @@ query p q = do mpath <- liftIO $ findHoogleBinPath p
                  Nothing   -> return []
                  Just path -> do (exitCode, output, err) <- liftIO $ readProcessWithExitCode path [q] ""
                                  case exitCode of
-                                   ExitSuccess -> do let search = runP hoogleElements () "hoogle-output" (output)
+                                   ExitSuccess -> do 
+                                                     liftIO $ logToStdout q
+                                                     liftIO $ logToStdout output
+                                                     let search = runP hoogleElements () "hoogle-output" (output)
                                                      case search of
                                                        Right result -> do dbResult <- result
                                                                           return dbResult

--- a/src/Server/PersistentCommands.hs
+++ b/src/Server/PersistentCommands.hs
@@ -28,6 +28,7 @@ data Command = LoadLocalDatabase FilePath Bool
              | HoogleCheckDatabase
              | GetDeclarationModules CurrentDatabase String
              | SetExtraHooglePath String
+             | GetDeclarationsFromPrefix CurrentDatabase String 
              | Quit
 
 data CurrentDatabase = AllPackages
@@ -118,6 +119,9 @@ executeCommand (GetModules cdb mname)  =
 executeCommand (GetDeclarations cdb mname) = 
                                            do decls <- runDb cdb (getDeclsInModule mname)
                                               return (toJSON decls, True)
+executeCommand (GetDeclarationsFromPrefix cdb prefix) = 
+                                           do decls <- runDb cdb (getDeclsFromPrefix prefix)
+                                              return (toJSON decls, True)
 executeCommand (HoogleQuery cdb query)       = 
                                            do extraH <- fmap extraHooglePath get
                                               results <- runDb cdb (\_ -> H.query extraH query)
@@ -149,6 +153,8 @@ instance FromJSON Command where
                                                                 <*> v .: "module"
                                "get-declarations"  -> GetDeclarations <$>v .: "db"
                                                                 <*> v .: "module"
+                               "get-decl-prefix"   -> GetDeclarationsFromPrefix <$>v .: "db"
+                                                                <*> v .: "prefix" 
                                "hoogle-query"      -> HoogleQuery <$> v .: "db"
                                                                 <*> v .: "query"
                                "hoogle-data"       -> pure HoogleDownloadData


### PR DESCRIPTION
This is used in the new content assist functionality (propose symbols not already imported)
